### PR TITLE
Added refundcancel endpoint

### DIFF
--- a/src/Omnipay/Adyen/Message/RefundRequest.php
+++ b/src/Omnipay/Adyen/Message/RefundRequest.php
@@ -109,6 +109,6 @@ class RefundRequest extends AbstractRequest
 
     public function getEndPoint()
     {
-        return ('https://pal-' . ($this->getTestMode() ? 'test' : 'live') . '.adyen.com/pal/servlet/Payment/v12/refund');
+        return ('https://pal-' . ($this->getTestMode() ? 'test' : 'live') . '.adyen.com/pal/servlet/Payment/v12/cancelOrRefund');
     }
 }


### PR DESCRIPTION
With this endpoint you can both cancel and refund a transaction without having to know upfront if a cancellation or refund is needed.

see https://docs.adyen.com/developers/api-manual#apiendpoints